### PR TITLE
Add new wait started and wait ended events

### DIFF
--- a/Package/Editor/TMPWriterEditor.cs
+++ b/Package/Editor/TMPWriterEditor.cs
@@ -36,6 +36,8 @@ namespace TMPEffects.Editor
         SerializedProperty onShowCharacterProp;
         SerializedProperty onStartWriterProp;
         SerializedProperty onStopWriterProp;
+        SerializedProperty onPauseStartedWriterProp;
+        SerializedProperty onPauseEndedWriterProp;
         SerializedProperty onResetWriterProp;
         SerializedProperty onSkipWriterProp;
         SerializedProperty onFinishWriterProp;
@@ -142,6 +144,8 @@ namespace TMPEffects.Editor
             onShowCharacterProp = serializedObject.FindProperty("OnCharacterShown");
             onStartWriterProp = serializedObject.FindProperty("OnStartWriter");
             onStopWriterProp = serializedObject.FindProperty("OnStopWriter");
+            onPauseStartedWriterProp = serializedObject.FindProperty("OnPauseStartedWriter");
+            onPauseEndedWriterProp = serializedObject.FindProperty("OnPauseEndedWriter");
             onResetWriterProp = serializedObject.FindProperty("OnResetWriter");
             onSkipWriterProp = serializedObject.FindProperty("OnSkipWriter");
             onFinishWriterProp = serializedObject.FindProperty("OnFinishWriter");
@@ -175,6 +179,10 @@ namespace TMPEffects.Editor
             writer.OnStartWriterPreview += CancelHideAfterFinish;
             writer.OnStopWriterPreview -= CancelHideAfterFinish;
             writer.OnStopWriterPreview += CancelHideAfterFinish;
+            writer.OnPauseStartedWriterPreview -= CancelHideAfterFinish;
+            writer.OnPauseStartedWriterPreview += CancelHideAfterFinish;
+            writer.OnPauseEndedWriterPreview -= CancelHideAfterFinish;
+            writer.OnPauseEndedWriterPreview += CancelHideAfterFinish;
             writer.OnFinishWriterPreview -= StartHideAfterFinish;
             writer.OnFinishWriterPreview += StartHideAfterFinish;
 
@@ -204,6 +212,8 @@ namespace TMPEffects.Editor
             writer.OnSkipWriterPreview -= CancelHideAfterFinish;
             writer.OnStartWriterPreview -= CancelHideAfterFinish;
             writer.OnStopWriterPreview -= CancelHideAfterFinish;
+            writer.OnPauseStartedWriterPreview -= CancelHideAfterFinish;
+            writer.OnPauseEndedWriterPreview -= CancelHideAfterFinish;
             writer.OnFinishWriterPreview -= StartHideAfterFinish;
 
             writer.OnResetWriterPreview -= UpdateProgress;
@@ -512,6 +522,8 @@ namespace TMPEffects.Editor
                 EditorGUILayout.PropertyField(onShowCharacterProp);
                 EditorGUILayout.PropertyField(onStartWriterProp);
                 EditorGUILayout.PropertyField(onStopWriterProp);
+                EditorGUILayout.PropertyField(onPauseStartedWriterProp);
+                EditorGUILayout.PropertyField(onPauseEndedWriterProp);
                 EditorGUILayout.PropertyField(onResetWriterProp);
                 EditorGUILayout.PropertyField(onSkipWriterProp);
                 EditorGUILayout.PropertyField(onFinishWriterProp);
@@ -661,7 +673,7 @@ namespace TMPEffects.Editor
                 case EventType.MouseDrag: if (writer.enabled) HandleMouseDrag(); break;
             }
 
-            // Reserve space  
+            // Reserve space
             GUILayoutUtility.GetRect(width, playerRect.y + playerHeight + dividerHeight);
 
             EditorGUI.DrawRect(dividerRect, new Color(48f / 255, 44f / 255, 44f / 255));

--- a/Package/Editor/TMPWriterEditor.cs
+++ b/Package/Editor/TMPWriterEditor.cs
@@ -36,8 +36,8 @@ namespace TMPEffects.Editor
         SerializedProperty onShowCharacterProp;
         SerializedProperty onStartWriterProp;
         SerializedProperty onStopWriterProp;
-        SerializedProperty onPauseStartedWriterProp;
-        SerializedProperty onPauseEndedWriterProp;
+        SerializedProperty onWaitStartedProp;
+        SerializedProperty onWaitEndedProp;
         SerializedProperty onResetWriterProp;
         SerializedProperty onSkipWriterProp;
         SerializedProperty onFinishWriterProp;
@@ -144,8 +144,8 @@ namespace TMPEffects.Editor
             onShowCharacterProp = serializedObject.FindProperty("OnCharacterShown");
             onStartWriterProp = serializedObject.FindProperty("OnStartWriter");
             onStopWriterProp = serializedObject.FindProperty("OnStopWriter");
-            onPauseStartedWriterProp = serializedObject.FindProperty("OnPauseStartedWriter");
-            onPauseEndedWriterProp = serializedObject.FindProperty("OnPauseEndedWriter");
+            onWaitStartedProp = serializedObject.FindProperty("OnWaitStarted");
+            onWaitEndedProp = serializedObject.FindProperty("OnWaitEnded");
             onResetWriterProp = serializedObject.FindProperty("OnResetWriter");
             onSkipWriterProp = serializedObject.FindProperty("OnSkipWriter");
             onFinishWriterProp = serializedObject.FindProperty("OnFinishWriter");
@@ -179,10 +179,10 @@ namespace TMPEffects.Editor
             writer.OnStartWriterPreview += CancelHideAfterFinish;
             writer.OnStopWriterPreview -= CancelHideAfterFinish;
             writer.OnStopWriterPreview += CancelHideAfterFinish;
-            writer.OnPauseStartedWriterPreview -= CancelHideAfterFinish;
-            writer.OnPauseStartedWriterPreview += CancelHideAfterFinish;
-            writer.OnPauseEndedWriterPreview -= CancelHideAfterFinish;
-            writer.OnPauseEndedWriterPreview += CancelHideAfterFinish;
+            writer.OnWaitStartedPreview -= CancelHideAfterFinish;
+            writer.OnWaitStartedPreview += CancelHideAfterFinish;
+            writer.OnWaitEndedPreview -= CancelHideAfterFinish;
+            writer.OnWaitEndedPreview += CancelHideAfterFinish;
             writer.OnFinishWriterPreview -= StartHideAfterFinish;
             writer.OnFinishWriterPreview += StartHideAfterFinish;
 
@@ -212,8 +212,8 @@ namespace TMPEffects.Editor
             writer.OnSkipWriterPreview -= CancelHideAfterFinish;
             writer.OnStartWriterPreview -= CancelHideAfterFinish;
             writer.OnStopWriterPreview -= CancelHideAfterFinish;
-            writer.OnPauseStartedWriterPreview -= CancelHideAfterFinish;
-            writer.OnPauseEndedWriterPreview -= CancelHideAfterFinish;
+            writer.OnWaitStartedPreview -= CancelHideAfterFinish;
+            writer.OnWaitEndedPreview -= CancelHideAfterFinish;
             writer.OnFinishWriterPreview -= StartHideAfterFinish;
 
             writer.OnResetWriterPreview -= UpdateProgress;
@@ -522,8 +522,8 @@ namespace TMPEffects.Editor
                 EditorGUILayout.PropertyField(onShowCharacterProp);
                 EditorGUILayout.PropertyField(onStartWriterProp);
                 EditorGUILayout.PropertyField(onStopWriterProp);
-                EditorGUILayout.PropertyField(onPauseStartedWriterProp);
-                EditorGUILayout.PropertyField(onPauseEndedWriterProp);
+                EditorGUILayout.PropertyField(onWaitStartedProp);
+                EditorGUILayout.PropertyField(onWaitEndedProp);
                 EditorGUILayout.PropertyField(onResetWriterProp);
                 EditorGUILayout.PropertyField(onSkipWriterProp);
                 EditorGUILayout.PropertyField(onFinishWriterProp);

--- a/Package/Runtime/Components/TMPWriter/TMPWriter.cs
+++ b/Package/Runtime/Components/TMPWriter/TMPWriter.cs
@@ -112,13 +112,13 @@ namespace TMPEffects.Components
         /// </summary>
         public UnityEvent<TMPWriter> OnStopWriter;
         /// <summary>
-        /// Raised when the TMPWriter pauses while writing (due to a wait).
+        /// Raised when the TMPWriter starts waiting.
         /// </summary>
-        public UnityEvent<TMPWriter> OnPauseStartedWriter;
+        public UnityEvent<TMPWriter> OnWaitStarted;
         /// <summary>
-        /// Raised when the TMPWriter unpauses writing (due to a ending a wait).
+        /// Raised when the TMPWriter ends waiting.
         /// </summary>
-        public UnityEvent<TMPWriter> OnPauseEndedWriter;
+        public UnityEvent<TMPWriter> OnWaitEnded;
         /// <summary>
         /// Raised when the TMPWriter is done writing the current text.
         /// </summary>
@@ -666,30 +666,30 @@ namespace TMPEffects.Components
             OnStopWriter?.Invoke(this);
         }
 
-        private void RaisePauseStartedWriterEvent()
+        private void RaiseWaitStartedEvent()
         {
 #if UNITY_EDITOR
             if (!Application.isPlaying)
             {
-                OnPauseStartedWriter?.Invoke(this);
+                OnWaitStarted?.Invoke(this);
                 return;
             }
 #endif
 
-            OnPauseStartedWriter?.Invoke(this);
+            OnWaitStarted?.Invoke(this);
         }
 
-        private void RaisePauseEndedWriterEvent()
+        private void RaiseWaitEndedEvent()
         {
 #if UNITY_EDITOR
             if (!Application.isPlaying)
             {
-                OnPauseEndedWriter?.Invoke(this);
+                OnWaitEnded?.Invoke(this);
                 return;
             }
 #endif
 
-            OnPauseEndedWriter?.Invoke(this);
+            OnWaitEnded?.Invoke(this);
         }
 
         private void RaiseSkipWriterEvent(int index)
@@ -760,9 +760,9 @@ namespace TMPEffects.Components
                 prevTime = useScaledTime ? Time.time : Time.unscaledTime;
                 if (shouldWait && waitAmount > 0)
                 {
-                    RaisePauseStartedWriterEvent();
+                    RaiseWaitStartedEvent();
                     yield return useScaledTime ? new WaitForSeconds(waitAmount) : new WaitForSecondsRealtime(waitAmount);
-                    RaisePauseEndedWriterEvent();
+                    RaiseWaitEndedEvent();
                 }
                 FixTimePost(waitAmount);
 
@@ -794,9 +794,9 @@ namespace TMPEffects.Components
                     FixTimePre(ref waitAmount);
                     if (shouldWait && waitAmount > 0)
                     {
-                        RaisePauseStartedWriterEvent();
+                        RaiseWaitStartedEvent();
                         yield return useScaledTime ? new WaitForSeconds(waitAmount) : new WaitForSecondsRealtime(waitAmount);
-                        RaisePauseEndedWriterEvent();
+                        RaiseWaitEndedEvent();
                     }
                     FixTimePost(waitAmount);
                     if (Mediator == null) yield break;
@@ -1135,8 +1135,8 @@ namespace TMPEffects.Components
         internal event VoidHandler OnFinishWriterPreview;
         internal event VoidHandler OnStartWriterPreview;
         internal event VoidHandler OnStopWriterPreview;
-        internal event VoidHandler OnPauseStartedWriterPreview;
-        internal event VoidHandler OnPauseEndedWriterPreview;
+        internal event VoidHandler OnWaitStartedPreview;
+        internal event VoidHandler OnWaitEndedPreview;
         internal event ResetHandler OnResetComponent;
 
 

--- a/Package/Runtime/Components/TMPWriter/TMPWriter.cs
+++ b/Package/Runtime/Components/TMPWriter/TMPWriter.cs
@@ -113,8 +113,9 @@ namespace TMPEffects.Components
         public UnityEvent<TMPWriter> OnStopWriter;
         /// <summary>
         /// Raised when the TMPWriter starts waiting.
+        /// The float parameter indicates the amount of time the TMPWriter will wait, in seconds.
         /// </summary>
-        public UnityEvent<TMPWriter> OnWaitStarted;
+        public UnityEvent<TMPWriter, float> OnWaitStarted;
         /// <summary>
         /// Raised when the TMPWriter ends waiting.
         /// </summary>
@@ -666,17 +667,17 @@ namespace TMPEffects.Components
             OnStopWriter?.Invoke(this);
         }
 
-        private void RaiseWaitStartedEvent()
+        private void RaiseWaitStartedEvent(float waitAmount)
         {
 #if UNITY_EDITOR
             if (!Application.isPlaying)
             {
-                OnWaitStarted?.Invoke(this);
+                OnWaitStarted?.Invoke(this, waitAmount);
                 return;
             }
 #endif
 
-            OnWaitStarted?.Invoke(this);
+            OnWaitStarted?.Invoke(this, waitAmount);
         }
 
         private void RaiseWaitEndedEvent()
@@ -760,7 +761,7 @@ namespace TMPEffects.Components
                 prevTime = useScaledTime ? Time.time : Time.unscaledTime;
                 if (shouldWait && waitAmount > 0)
                 {
-                    RaiseWaitStartedEvent();
+                    RaiseWaitStartedEvent(waitAmount);
                     yield return useScaledTime ? new WaitForSeconds(waitAmount) : new WaitForSecondsRealtime(waitAmount);
                     RaiseWaitEndedEvent();
                 }
@@ -794,7 +795,7 @@ namespace TMPEffects.Components
                     FixTimePre(ref waitAmount);
                     if (shouldWait && waitAmount > 0)
                     {
-                        RaiseWaitStartedEvent();
+                        RaiseWaitStartedEvent(waitAmount);
                         yield return useScaledTime ? new WaitForSeconds(waitAmount) : new WaitForSecondsRealtime(waitAmount);
                         RaiseWaitEndedEvent();
                     }
@@ -848,8 +849,12 @@ namespace TMPEffects.Components
             //    invokable.Trigger();
 
             //    FixTimePre(ref waitAmount);
-            //    if (shouldWait && waitAmount > 0) yield return useScaledTime ? new WaitForSeconds(waitAmount) : new WaitForSecondsRealtime(waitAmount);
-
+            //    if (shouldWait && waitAmount > 0)
+            //    {
+            //        RaiseWaitStartedEvent(waitAmount);
+            //        yield return useScaledTime ? new WaitForSeconds(waitAmount) : new WaitForSecondsRealtime(waitAmount);
+            //        RaiseWaitEndedEvent();
+            //    }
             //    if (Mediator == null) yield break;
             //    if (continueConditions != null) yield return HandleWaitConditions();
             //    if (Mediator == null) yield break;
@@ -1070,7 +1075,12 @@ namespace TMPEffects.Components
 
                 if (block)
                 {
-                    if (shouldWait) yield return new WaitForSeconds(waitAmount);
+                    if (shouldWait && waitAmount > 0)
+                    {
+                        RaiseWaitStartedEvent(waitAmount);
+                        yield return useScaledTime ? new WaitForSeconds(waitAmount) : new WaitForSecondsRealtime(waitAmount);
+                        RaiseWaitEndedEvent();
+                    }
                     if (continueConditions != null) yield return HandleWaitConditions();
                 }
 
@@ -1092,7 +1102,12 @@ namespace TMPEffects.Components
 
                 if (block)
                 {
-                    if (shouldWait) yield return new WaitForSeconds(waitAmount);
+                    if (shouldWait && waitAmount > 0)
+                    {
+                        RaiseWaitStartedEvent(waitAmount);
+                        yield return useScaledTime ? new WaitForSeconds(waitAmount) : new WaitForSecondsRealtime(waitAmount);
+                        RaiseWaitEndedEvent();
+                    }
                     if (continueConditions != null) yield return HandleWaitConditions();
                 }
 


### PR DESCRIPTION
## Summary

Adds new "On Pause Started" and "On Pause Ended" events to TMPWriter that activate before and after wait logic requested by invocables.

## Changes

* New "On Pause Started Writer" and "On Pause Ended Writer" events in the TMP Writer Editor view
   * `Package/Editor/TMPWriterEditor.cs`
* New pause start and end events that trigger before and after wait calls. Inspired by logic from Yarn Spinner's Effects.cs
   * `Package/Runtime/Components/TMPWriter/TMPWriter.cs`

## Investigation

Inspired by logic from Yarn Spinner's [Effects.cs](https://github.com/YarnSpinnerTool/YarnSpinner-Unity/blob/main/Runtime/Views/Effects.cs) `PausableTypewriter` function
```c#
    if (text.maxVisibleCharacters == pausePositions.Peek().Item1)
    {
        var pause = pausePositions.Pop();
        onPauseStarted?.Invoke();
        yield return Effects.InterruptableWait(pause.Item2, stopToken);  // <-- events raised before/after wait
        onPauseEnded?.Invoke();
```

Here's a test GIF showing how the pause start and end events trigger an event for a talking robot to shift between talking and paused states, with debug logs to note the call counts for each pause event as well.
![TMPWriterPauseEvent](https://github.com/user-attachments/assets/eed4a944-2281-44a1-bd82-4e657c8dd860)

The Yarn dialogue file used:
```
title: Start
---
Narrator: <+grow>Hi</+grow>,  <!wait=.3>I'm the <wave>narrator</wave> for this beginner's guide!
Narrator: I'm talking to you with <palette>Yarn Spinner</palette>!
Narrator: Here's a wait test! <!wait=.3>One second... <!wait=1> Two seconds... <!wait=2>And lastly, <!wait=.3>Three seconds!<!wait=3> <+grow>..done!</+grow>
Narrator: What do you think of all this, <!wait=.3>then?
    -> It's alright, <!wait=.3><wave>I guess</wave>.
        Narrator: Well, <!wait=.3>that's not very nice.
        Narrator: I'm trying my best here.
    -> It's great. <!wait=.3>I <grow>love</grow> it.
        Narrator: Oh, <!wait=.3>you're too kind.
        Narrator: I'm just doing my job.
Narrator: Anyways, <!wait=.3>Let's start over to help with dialogue testing.
<<jump Start>>
===
```
